### PR TITLE
fix react-native support with chrome debugger

### DIFF
--- a/index.js
+++ b/index.js
@@ -404,7 +404,7 @@ function formatted(obj, method) {
 // Return whether a URL is a cross-domain request.
 function is_crossDomain(url) {
   // Fix for React Native. CORS does noet exist in that environment
-  if (! window.location) {
+  if (!!window.__fbBatchedBridge) {
     return false;
   }
 


### PR DESCRIPTION
When using chrome debugger, window/global becomes an instance of debuggerWorker where there IS a  "window.location." This is just another attempt at a workaround, #ifndef style.
